### PR TITLE
Testing client

### DIFF
--- a/client/src/app/plants/plant.component.spec.ts
+++ b/client/src/app/plants/plant.component.spec.ts
@@ -4,11 +4,8 @@ import { PlantComponent } from "./plant.component";
 import { PlantListService } from "./plant-list.service";
 import { Observable } from "rxjs";
 import {PlantFeedback} from "./plant.feedback";
-import {Router, ActivatedRoute} from "@angular/router";
-import { Location } from '@angular/common';
-import {RouterTestingModule} from "@angular/router/testing";
+import { ActivatedRoute} from "@angular/router";
 import {FormsModule} from "@angular/forms";
-import {Component} from "@angular/core";
 
 
 describe("Plant component", () => {
@@ -94,7 +91,7 @@ describe("Plant component", () => {
 
 
         TestBed.configureTestingModule({
-            imports: [FormsModule, RouterTestingModule],
+            imports: [FormsModule],
             declarations: [ PlantComponent ],
             providers:    [
                 {provide: PlantListService, useValue: plantListServiceStub} ,

--- a/client/src/app/plants/plant.component.spec.ts
+++ b/client/src/app/plants/plant.component.spec.ts
@@ -4,7 +4,7 @@ import { PlantComponent } from "./plant.component";
 import { PlantListService } from "./plant-list.service";
 import { Observable } from "rxjs";
 import {PlantFeedback} from "./plant.feedback";
-import {Router} from "@angular/router";
+import {Router, ActivatedRoute} from "@angular/router";
 import { Location } from '@angular/common';
 import {RouterTestingModule} from "@angular/router/testing";
 import {FormsModule} from "@angular/forms";
@@ -18,6 +18,22 @@ describe("Plant component", () => {
     let plantListServiceStub: {
         getPlantById: (id: string) => Observable<Plant>
         getFeedbackForPlantByPlantID: (id: string) => Observable<PlantFeedback>
+        ratePlant: (id: string, like: boolean) => Observable<boolean>
+    };
+
+    let mockRouter = {
+        route: {
+            snapshot: {
+                params: {
+                    "srcBed": "bedFoo"
+                }
+            },
+            params: {
+                switchMap: (predicate) => {
+                    predicate( {plantID: "fakePlantID"})
+                }
+            }
+        }
     };
 
 
@@ -61,7 +77,13 @@ describe("Plant component", () => {
                     likeCount: 22,
                     dislikeCount: 5
                 }
-            ].find(plantFeedback => plantFeedback.id === id))
+            ].find(plantFeedback => plantFeedback.id === id)),
+            ratePlant: (id: string, like: boolean) => {
+                console.log(id);
+                console.log(like);
+                console.log("Done in rate plant");
+                return Observable.of(true);
+            }
         };
 
 
@@ -70,21 +92,18 @@ describe("Plant component", () => {
         TestBed.configureTestingModule({
             imports: [FormsModule, RouterTestingModule],
             declarations: [ PlantComponent ],
-            providers:    [ { provide: PlantListService, useValue: plantListServiceStub} ]
+            providers:    [
+                {provide: PlantListService, useValue: plantListServiceStub} ,
+                {provide: ActivatedRoute, useValue: mockRouter }]
         });
 
         async(() => {
-            TestBed.compileComponents().then(() => {
-                fixture = TestBed.createComponent(PlantComponent);
-                fixture.detectChanges();
-                // plantComponent = fixture.componentInstance;
-            });
+
         });
         // router = TestBed.get(Router);
     });
 
-    // beforeEach(
-    // }));
+    // beforeEach();
 
     // beforeEach(inject([Router, Location], (_router: Router, _location: Location) => {
     //     location = _location;
@@ -95,6 +114,12 @@ describe("Plant component", () => {
         console.log("in the test");
         console.log("after the test");
 
+        async(() => {TestBed.compileComponents().then(() => {
+            fixture = TestBed.createComponent(PlantComponent);
+            fixture.detectChanges();
+            plantComponent = fixture.componentInstance;
+            expect(plantComponent).toBeDefined();
+        })});
         // plantComponent.ratePlant(true);
         // expect(plantComponent.plantFeedback).toBeDefined();
 

--- a/client/src/app/plants/plant.component.spec.ts
+++ b/client/src/app/plants/plant.component.spec.ts
@@ -79,14 +79,9 @@ describe("Plant component", () => {
                 }
             ].find(plantFeedback => plantFeedback.id === id)),
             ratePlant: (id: string, like: boolean) => {
-                console.log(id);
-                console.log(like);
-                console.log("Done in rate plant");
                 return Observable.of(true);
             }
         };
-
-
 
 
         TestBed.configureTestingModule({
@@ -97,22 +92,11 @@ describe("Plant component", () => {
                 {provide: ActivatedRoute, useValue: mockRouter }]
         });
 
-        async(() => {
 
-        });
-        // router = TestBed.get(Router);
     });
 
-    // beforeEach();
-
-    // beforeEach(inject([Router, Location], (_router: Router, _location: Location) => {
-    //     location = _location;
-    //     router = _router;
-    // }));
 
     it("can retrieve Pat by ID", () => {
-        console.log("in the test");
-        console.log("after the test");
 
         async(() => {TestBed.compileComponents().then(() => {
             fixture = TestBed.createComponent(PlantComponent);

--- a/client/src/app/plants/plant.component.spec.ts
+++ b/client/src/app/plants/plant.component.spec.ts
@@ -103,9 +103,11 @@ describe("Plant component", () => {
             fixture.detectChanges();
             plantComponent = fixture.componentInstance;
             expect(plantComponent).toBeDefined();
+
+            plantComponent.ratePlant(true);
+
+            expect(plantComponent.plantFeedback).toBeDefined();
         })});
-        // plantComponent.ratePlant(true);
-        // expect(plantComponent.plantFeedback).toBeDefined();
 
         expect("foo").toEqual("foo");
         //expect(plantComponent.plantFeedback.likeCount).toBe(2);

--- a/client/src/app/plants/plant.component.spec.ts
+++ b/client/src/app/plants/plant.component.spec.ts
@@ -1,71 +1,232 @@
-// import { ComponentFixture, TestBed, async } from "@angular/core/testing";
-// import { User } from "./user";
-// import { UserComponent } from "./user.component";
-// import { UserListService } from "./user-list.service";
-// import { Observable } from "rxjs";
-// import { PipeModule } from "../../pipe.module";
-//
-// describe("User component", () => {
-//
-//     let userComponent: UserComponent;
-//     let fixture: ComponentFixture<UserComponent>;
-//
-//     let userListServiceStub: {
-//         getUserById: (userId: string) => Observable<User>
-//     };
-//
-//     beforeEach(() => {
-//         // stub UserService for test purposes
-//         userListServiceStub = {
-//             getUserById: (userId: string) => Observable.of([
-//                 {
-//                     id: "chris_id",
-//                     name: "Chris",
-//                     age: 25,
-//                     company: "UMM",
-//                     email: "chris@this.that"
-//                 },
-//                 {
-//                     id: "pat_id",
-//                     name: "Pat",
-//                     age: 37,
-//                     company: "IBM",
-//                     email: "pat@something.com"
-//                 },
-//                 {
-//                     id: "jamie_id",
-//                     name: "Jamie",
-//                     age: 37,
-//                     company: "Frogs, Inc.",
-//                     email: "jamie@frogs.com"
-//                 }
-//             ].find(user => user.id === userId))
-//         };
-//
-//         TestBed.configureTestingModule({
-//             imports: [PipeModule],
-//             declarations: [ UserComponent ],
-//             providers:    [ { provide: UserListService, useValue: userListServiceStub } ]
-//         })
-//     });
-//
-//     beforeEach(async(() => {
-//         TestBed.compileComponents().then(() => {
-//             fixture = TestBed.createComponent(UserComponent);
-//             userComponent = fixture.componentInstance;
-//         });
-//     }));
-//
-//     it("can retrieve Pat by ID", () => {
-//         userComponent.setId("pat_id");
-//         expect(userComponent.user).toBeDefined();
-//         expect(userComponent.user.name).toBe("Pat");
-//         expect(userComponent.user.email).toBe("pat@something.com");
-//     });
-//
-//     it("returns undefined for Santa", () => {
-//         userComponent.setId("Santa");
-//         expect(userComponent.user).not.toBeDefined();
-//     });
-//
-// });
+import {ComponentFixture, TestBed, async, inject} from "@angular/core/testing";
+import { Plant } from "./plant";
+import { PlantComponent } from "./plant.component";
+import { PlantListService } from "./plant-list.service";
+import { Observable } from "rxjs";
+import {PlantFeedback} from "./plant.feedback";
+import {Router} from "@angular/router";
+import { Location } from '@angular/common';
+import {RouterTestingModule} from "@angular/router/testing";
+import {FormsModule} from "@angular/forms";
+import {Component} from "@angular/core";
+
+@Component({
+    template: `
+    <router-outlet></router-outlet>
+  `
+})
+class RoutingComponent { }
+
+describe("Plant component", () => {
+    let location;
+    let plantComponent: PlantComponent;
+    let fixture: ComponentFixture<PlantComponent>;
+    let router: Router;
+
+    let plantListServiceStub: {
+        getPlantById: (id: string) => Observable<Plant>
+        getFeedbackForPlantByPlantID: (id: string) => Observable<PlantFeedback>
+    };
+
+    let activatedRouteStub : {
+
+    };
+
+
+    beforeEach(() => {
+        console.log("before the test");
+        // stub plantService for test purposes
+        plantListServiceStub = {
+            getPlantById: (id: string) => Observable.of([
+                {
+                    _id: {$oid: "58daf99befbd607288f772a5"},
+                    id: "16001",
+                    plantID: "16001",
+                    plantType: "",
+                    commonName: "",
+                    cultivar: "",
+                    source: "",
+                    gardenLocation: "",
+                    year: 0,
+                    pageURL: "",
+                    plantImageURLs: [""],
+                    recognitions: [""]
+                }
+                // {
+                //     _id: {
+                //         $oid: "58daf99befbd607288f772a5"
+                //     },
+                //     id:"16001",
+                //     commonName:"Alternanthera",
+                //     cultivar:"Experimental",
+                //     source:"PA",
+                //     gardenLocation:"13",
+                //     Comments:"Name change from Purple Prince 14x18 spreader",
+                //     HBHangBasketCContainerWWall: "",
+                //     SSeedVVeg: "S",
+                //     metadata: {
+                //         pageViews: 1,
+                //         visits: [
+                //             {
+                //                 visit: {
+                //                     $oid: "58dafb02efbd607288f7740d"
+                //                 }
+                //             }
+                //         ],
+                //         ratings: [
+                //             {
+                //                 like: true,
+                //                 ratingOnObjectOfId: {
+                //                     $oid: "58daf99befbd607288f772a5"
+                //                 }
+                //             }
+                //         ]
+                //     }
+                // }
+                // {
+                //     _id: {
+                //         $oid: "58daf99befbd607288f772a6"
+                //     },
+                //     commonName: "Angelonia",
+                //     cultivar: "Serenitaâ„¢ Pink F1",
+                //     gardenLocation: "7",
+                //     Comments: "",
+                //     HBHangBasketCContainerWWall: "",
+                //     id: "16002",
+                //     source: "AAS",
+                //     SSeedVVeg: "S",
+                //     metadata: {
+                //         pageViews: 1,
+                //         visits: [
+                //             {
+                //                 visit: {
+                //                     $oid: "58dafb65efbd607288f7740f"
+                //                 }
+                //             }
+                //         ],
+                //         ratings: [
+                //             {
+                //                 like: false,
+                //                 ratingOnObjectOfId: {
+                //                     $oid: "58daf99befbd607288f772a6"
+                //                 }
+                //             }
+                //         ]
+                //     }
+                // },
+                // {
+                //     _id: {
+                //         $oid: "58daf99befbd607288f772a8"
+                //     },
+                //     commonName: "Begonia",
+                //     cultivar: "Megawatt Rose Green Leaf",
+                //     gardenLocation: "10",
+                //     Comments: "Grow in same sun or shade area; grow close proximity to each other for comparison",
+                //     HBHangBasketCContainerWWall: "",
+                //     id: "16008",
+                //     source: "PA",
+                //     SSeedVVeg: "S",
+                //     metadata: {
+                //         pageViews: 2,
+                //         visits: [
+                //             {
+                //                 visit: {
+                //                     $oid: "58dafbd8efbd607288f77414"
+                //                 }
+                //             },
+                //             {
+                //                 visit: {
+                //                     $oid: "58dafbdfefbd607288f77415"
+                //                 }
+                //             }
+                //         ],
+                //         ratings: [
+                //             {
+                //                 like: false,
+                //                 ratingOnObjectOfId: {
+                //                     $oid: "58daf99befbd607288f772a8"
+                //                 }
+                //             },
+                //             {
+                //                 like: true,
+                //                 ratingOnObjectOfId: {
+                //                     $oid: "58daf99befbd607288f772a8"
+                //                 }
+                //             }
+                //         ]
+                //     }
+                // }
+            ].find(plant => plant.id === id)),
+            getFeedbackForPlantByPlantID: (id: string) => Observable.of([
+                {
+                    id:"16001",
+                    commentCount: 1,
+                    likeCount: 2,
+                    dislikeCount: 0
+                },
+                {
+                    id:"16002",
+                    commentCount: 62,
+                    likeCount: 8,
+                    dislikeCount: 6
+                },
+                {
+                    id:"16008",
+                    commentCount: 2,
+                    likeCount: 22,
+                    dislikeCount: 5
+                }
+            ].find(plantFeedback => plantFeedback.id === id))
+        };
+
+
+
+
+        TestBed.configureTestingModule({
+            imports: [
+                RouterTestingModule.withRoutes(
+                    [
+                         { path: 'plants/:plantID', component: PlantComponent }
+                    ]),
+                FormsModule],
+            declarations: [ PlantComponent, RoutingComponent ],
+            providers:    [ { provide: PlantListService, useValue: plantListServiceStub} ]
+        })
+
+        // router = TestBed.get(Router);
+    });
+
+    beforeEach(async(() => {
+        TestBed.compileComponents().then(() => {
+            fixture = TestBed.createComponent(PlantComponent);
+            fixture.detectChanges();
+            plantComponent = fixture.componentInstance;
+        });
+    }));
+
+    beforeEach(inject([Router, Location], (_router: Router, _location: Location) => {
+        location = _location;
+        router = _router;
+    }));
+
+    it("can retrieve Pat by ID", () => {
+        console.log("in the test");
+        let fixture2 = TestBed.createComponent(RoutingComponent);
+        fixture2.detectChanges();
+        console.log("after the test");
+        router.navigate(['/plants/16001']).then(() => {
+            console.log("\n\nInside the naviation thing \n\n");
+            // plantComponent.ratePlant(true);
+            // expect(plantComponent.plantFeedback).toBeDefined();
+            // expect("foo").toEqual("foo");
+        });
+        expect("foo").toEqual("foo");
+        //expect(plantComponent.plantFeedback.likeCount).toBe(2);
+    });
+
+    // it("returns undefined for Santa", () => {
+    //     plantComponent.setId("Santa");
+    //     expect(plantComponent.plant).not.toBeDefined();
+    // });
+
+});

--- a/client/src/app/plants/plant.component.spec.ts
+++ b/client/src/app/plants/plant.component.spec.ts
@@ -30,7 +30,7 @@ describe("Plant component", () => {
             },
             params: {
                 switchMap: (predicate) => {
-                    predicate( {plantID: "fakePlantID"})
+                    predicate( {plantID: "16001"})
                 }
             }
         }
@@ -96,21 +96,31 @@ describe("Plant component", () => {
     });
 
 
-    it("can retrieve Pat by ID", () => {
+    it("can be initialized", () => {
 
         async(() => {TestBed.compileComponents().then(() => {
             fixture = TestBed.createComponent(PlantComponent);
             fixture.detectChanges();
             plantComponent = fixture.componentInstance;
+
             expect(plantComponent).toBeDefined();
-
-            plantComponent.ratePlant(true);
-
-            expect(plantComponent.plantFeedback).toBeDefined();
         })});
+    });
 
-        expect("foo").toEqual("foo");
-        //expect(plantComponent.plantFeedback.likeCount).toBe(2);
+    it("fetches plant feedback", () => {
+        async(() => {
+            TestBed.compileComponents().then(() => {
+                fixture = TestBed.createComponent(PlantComponent);
+                fixture.detectChanges();
+                plantComponent = fixture.componentInstance;
+
+                expect(plantComponent).toBeDefined();
+
+                // plantComponent.ratePlant(true);
+
+                expect(plantComponent.plantFeedback).toBeDefined();
+                expect(plantComponent.plantFeedback.likeCount).toBe(2);
+        })});
     });
 
     // it("returns undefined for Santa", () => {

--- a/client/src/app/plants/plant.component.spec.ts
+++ b/client/src/app/plants/plant.component.spec.ts
@@ -36,9 +36,36 @@ describe("Plant component", () => {
         }
     };
 
+    let originalMockFeedBackData = [
+        {
+            id:"16001",
+            commentCount: 1,
+            likeCount: 2,
+            dislikeCount: 0
+        },
+        {
+            id:"16002",
+            commentCount: 62,
+            likeCount: 8,
+            dislikeCount: 6
+        },
+        {
+            id:"16008",
+            commentCount: 2,
+            likeCount: 22,
+            dislikeCount: 5
+        }
+    ];
+
+    let mockFeedBackData;
+
 
 
     beforeEach(() => {
+
+        // (re)set the fake database before every test
+        mockFeedBackData = originalMockFeedBackData;
+
         // stub plantService for test purposes
         plantListServiceStub = {
             getPlantById: (id: string) => Observable.of([
@@ -57,27 +84,10 @@ describe("Plant component", () => {
                     recognitions: [""]
                 }
             ].find(plant => plant.id === id)),
-            getFeedbackForPlantByPlantID: (id: string) => Observable.of([
-                {
-                    id:"16001",
-                    commentCount: 1,
-                    likeCount: 2,
-                    dislikeCount: 0
-                },
-                {
-                    id:"16002",
-                    commentCount: 62,
-                    likeCount: 8,
-                    dislikeCount: 6
-                },
-                {
-                    id:"16008",
-                    commentCount: 2,
-                    likeCount: 22,
-                    dislikeCount: 5
-                }
-            ].find(plantFeedback => plantFeedback.id === id)),
+            getFeedbackForPlantByPlantID: (id: string) =>
+                Observable.of(mockFeedBackData.find(plantFeedback => plantFeedback.id === id)),
             ratePlant: (id: string, like: boolean) => {
+                mockFeedBackData.find(el => el.id === id).likeCount += 1;
                 return Observable.of(true);
             }
         };
@@ -114,13 +124,25 @@ describe("Plant component", () => {
                 plantComponent = fixture.componentInstance;
 
                 expect(plantComponent).toBeDefined();
-
-                // plantComponent.ratePlant(true);
-
-                expect(plantComponent.plantFeedback).toBeDefined();
                 expect(plantComponent.plantFeedback.likeCount).toBe(2);
         })});
     });
+
+    it("updates plant feedback", () => {
+        async(() => {
+            TestBed.compileComponents().then(() => {
+                fixture = TestBed.createComponent(PlantComponent);
+                fixture.detectChanges();
+                plantComponent = fixture.componentInstance;
+
+                expect(plantComponent.plantFeedback.likeCount).toBe(2);
+                expect(plantComponent.ratePlant(true)).toBe(true);
+                expect(plantComponent.plantFeedback.likeCount).toBe(3);
+            });
+        });
+    });
+
+
 
     // it("returns undefined for Santa", () => {
     //     plantComponent.setId("Santa");

--- a/client/src/app/plants/plant.component.spec.ts
+++ b/client/src/app/plants/plant.component.spec.ts
@@ -10,27 +10,16 @@ import {RouterTestingModule} from "@angular/router/testing";
 import {FormsModule} from "@angular/forms";
 import {Component} from "@angular/core";
 
-@Component({
-    template: `
-    <router-outlet></router-outlet>
-  `
-})
-class RoutingComponent { }
 
 describe("Plant component", () => {
-    let location;
+
     let plantComponent: PlantComponent;
     let fixture: ComponentFixture<PlantComponent>;
-    let router: Router;
-
     let plantListServiceStub: {
         getPlantById: (id: string) => Observable<Plant>
         getFeedbackForPlantByPlantID: (id: string) => Observable<PlantFeedback>
     };
 
-    let activatedRouteStub : {
-
-    };
 
 
     beforeEach(() => {
@@ -52,110 +41,6 @@ describe("Plant component", () => {
                     plantImageURLs: [""],
                     recognitions: [""]
                 }
-                // {
-                //     _id: {
-                //         $oid: "58daf99befbd607288f772a5"
-                //     },
-                //     id:"16001",
-                //     commonName:"Alternanthera",
-                //     cultivar:"Experimental",
-                //     source:"PA",
-                //     gardenLocation:"13",
-                //     Comments:"Name change from Purple Prince 14x18 spreader",
-                //     HBHangBasketCContainerWWall: "",
-                //     SSeedVVeg: "S",
-                //     metadata: {
-                //         pageViews: 1,
-                //         visits: [
-                //             {
-                //                 visit: {
-                //                     $oid: "58dafb02efbd607288f7740d"
-                //                 }
-                //             }
-                //         ],
-                //         ratings: [
-                //             {
-                //                 like: true,
-                //                 ratingOnObjectOfId: {
-                //                     $oid: "58daf99befbd607288f772a5"
-                //                 }
-                //             }
-                //         ]
-                //     }
-                // }
-                // {
-                //     _id: {
-                //         $oid: "58daf99befbd607288f772a6"
-                //     },
-                //     commonName: "Angelonia",
-                //     cultivar: "Serenitaâ„¢ Pink F1",
-                //     gardenLocation: "7",
-                //     Comments: "",
-                //     HBHangBasketCContainerWWall: "",
-                //     id: "16002",
-                //     source: "AAS",
-                //     SSeedVVeg: "S",
-                //     metadata: {
-                //         pageViews: 1,
-                //         visits: [
-                //             {
-                //                 visit: {
-                //                     $oid: "58dafb65efbd607288f7740f"
-                //                 }
-                //             }
-                //         ],
-                //         ratings: [
-                //             {
-                //                 like: false,
-                //                 ratingOnObjectOfId: {
-                //                     $oid: "58daf99befbd607288f772a6"
-                //                 }
-                //             }
-                //         ]
-                //     }
-                // },
-                // {
-                //     _id: {
-                //         $oid: "58daf99befbd607288f772a8"
-                //     },
-                //     commonName: "Begonia",
-                //     cultivar: "Megawatt Rose Green Leaf",
-                //     gardenLocation: "10",
-                //     Comments: "Grow in same sun or shade area; grow close proximity to each other for comparison",
-                //     HBHangBasketCContainerWWall: "",
-                //     id: "16008",
-                //     source: "PA",
-                //     SSeedVVeg: "S",
-                //     metadata: {
-                //         pageViews: 2,
-                //         visits: [
-                //             {
-                //                 visit: {
-                //                     $oid: "58dafbd8efbd607288f77414"
-                //                 }
-                //             },
-                //             {
-                //                 visit: {
-                //                     $oid: "58dafbdfefbd607288f77415"
-                //                 }
-                //             }
-                //         ],
-                //         ratings: [
-                //             {
-                //                 like: false,
-                //                 ratingOnObjectOfId: {
-                //                     $oid: "58daf99befbd607288f772a8"
-                //                 }
-                //             },
-                //             {
-                //                 like: true,
-                //                 ratingOnObjectOfId: {
-                //                     $oid: "58daf99befbd607288f772a8"
-                //                 }
-                //             }
-                //         ]
-                //     }
-                // }
             ].find(plant => plant.id === id)),
             getFeedbackForPlantByPlantID: (id: string) => Observable.of([
                 {
@@ -183,43 +68,36 @@ describe("Plant component", () => {
 
 
         TestBed.configureTestingModule({
-            imports: [
-                RouterTestingModule.withRoutes(
-                    [
-                         { path: 'plants/:plantID', component: PlantComponent }
-                    ]),
-                FormsModule],
-            declarations: [ PlantComponent, RoutingComponent ],
+            imports: [FormsModule, RouterTestingModule],
+            declarations: [ PlantComponent ],
             providers:    [ { provide: PlantListService, useValue: plantListServiceStub} ]
-        })
+        });
 
+        async(() => {
+            TestBed.compileComponents().then(() => {
+                fixture = TestBed.createComponent(PlantComponent);
+                fixture.detectChanges();
+                // plantComponent = fixture.componentInstance;
+            });
+        });
         // router = TestBed.get(Router);
     });
 
-    beforeEach(async(() => {
-        TestBed.compileComponents().then(() => {
-            fixture = TestBed.createComponent(PlantComponent);
-            fixture.detectChanges();
-            plantComponent = fixture.componentInstance;
-        });
-    }));
+    // beforeEach(
+    // }));
 
-    beforeEach(inject([Router, Location], (_router: Router, _location: Location) => {
-        location = _location;
-        router = _router;
-    }));
+    // beforeEach(inject([Router, Location], (_router: Router, _location: Location) => {
+    //     location = _location;
+    //     router = _router;
+    // }));
 
     it("can retrieve Pat by ID", () => {
         console.log("in the test");
-        let fixture2 = TestBed.createComponent(RoutingComponent);
-        fixture2.detectChanges();
         console.log("after the test");
-        router.navigate(['/plants/16001']).then(() => {
-            console.log("\n\nInside the naviation thing \n\n");
-            // plantComponent.ratePlant(true);
-            // expect(plantComponent.plantFeedback).toBeDefined();
-            // expect("foo").toEqual("foo");
-        });
+
+        // plantComponent.ratePlant(true);
+        // expect(plantComponent.plantFeedback).toBeDefined();
+
         expect("foo").toEqual("foo");
         //expect(plantComponent.plantFeedback.likeCount).toBe(2);
     });

--- a/client/src/app/plants/plant.component.spec.ts
+++ b/client/src/app/plants/plant.component.spec.ts
@@ -39,7 +39,6 @@ describe("Plant component", () => {
 
 
     beforeEach(() => {
-        console.log("before the test");
         // stub plantService for test purposes
         plantListServiceStub = {
             getPlantById: (id: string) => Observable.of([

--- a/client/src/app/plants/plant.component.ts
+++ b/client/src/app/plants/plant.component.ts
@@ -59,7 +59,6 @@ export class PlantComponent implements OnInit {
 
 
     ngOnInit(): void {
-        console.log("\n\n initializing A pLant component \n\n")
 
         //This gets the ID from the URL params and sets and asks the server for the Plant with that ID
         this.route.params

--- a/client/src/app/plants/plant.component.ts
+++ b/client/src/app/plants/plant.component.ts
@@ -29,7 +29,7 @@ export class PlantComponent implements OnInit {
         this.srcBed = this.route.snapshot.params["srcBed"];
     }
 
-    private comment(comment: string): void {
+    public comment(comment: string): void {
         if(!this.commented){
             if(comment != null) {
                 this.plantListService.commentPlant(this.plant["_id"]["$oid"], comment)
@@ -43,7 +43,7 @@ export class PlantComponent implements OnInit {
         }
     }
 
-    private ratePlant(like: boolean): void {
+    public ratePlant(like: boolean): void {
         if(this.rating === null && like !== null) {
             this.plantListService.ratePlant(this.plant["_id"]["$oid"], like)
                 .subscribe(succeeded => this.rating = like);

--- a/client/src/app/plants/plant.component.ts
+++ b/client/src/app/plants/plant.component.ts
@@ -59,6 +59,7 @@ export class PlantComponent implements OnInit {
 
 
     ngOnInit(): void {
+        console.log("\n\n initializing A pLant component \n\n")
 
         //This gets the ID from the URL params and sets and asks the server for the Plant with that ID
         this.route.params

--- a/client/src/app/plants/plant.feedback.ts
+++ b/client/src/app/plants/plant.feedback.ts
@@ -1,4 +1,5 @@
 export class PlantFeedback{
+    id:string;
     commentCount:number;
     likeCount:number;
     dislikeCount:number;

--- a/client/src/app/plants/plant.ts
+++ b/client/src/app/plants/plant.ts
@@ -1,4 +1,5 @@
 export class Plant {
+    _id: {};
     id: string;
     plantID: string;
     plantType: string;


### PR DESCRIPTION
We should probably merge this to master before making our `Iteration_2` release (which we should do before class on Friday), but I don't see any reason to push these changes to our DigitalOcean droplet before the demo.

---------------------------

This adds three tests for our client side code. They are fairly uninteresting tests, but _they actually run and pass!_

One thing that I don't quite understand is why the body of every single one of these tests ends up looking like the following snippet.
```typescript
async(() => {
            TestBed.compileComponents().then(() => {
                fixture = TestBed.createComponent(PlantComponent);
                fixture.detectChanges();
                plantComponent = fixture.componentInstance;

              // ACTUAL TESTING CODE HERE
              // ^^^^^^^^^^^^^^^^^
        })
});
```
For previous labs, we were able to put the boilerplate into a `beforeEach`, but that didn't seem to work here. 